### PR TITLE
Fix requirements.txt to match actual app dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-fastapi
-uvicorn[standard]
-pyserial
-websockets
-python-multipart
+streamlit
+numpy
+scikit-fmm
+scikit-image
+plotly


### PR DESCRIPTION
requirements.txt was listing FastAPI dependencies that don't belong to this project — replaced with the actual dependencies the app uses